### PR TITLE
Updating theme version to 5.6.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-gem "jumbo-jekyll-theme", "5.5.1"
+gem "jumbo-jekyll-theme", "5.6.5"
 group :jekyll_plugins do
   gem "jekyll-data"
 end

--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -41,8 +41,8 @@ blog:
             display: true
             count: 5
 #Google analytics
-google:
-    analytics: UA-16756069-29
+google_analytics:
+  production: UA-16756069-29
 # Shema.org settings used in the schema.html include.
 schema:
     enabled: false

--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -1,4 +1,4 @@
-favicon: favicon.png
+favicon: /assets/images/favicon.png
 search-label: ArmNNWebsite
 name: ArmNNWebsite
 # slogan: Open Source Secure World Software

--- a/_data/universal-nav.yml
+++ b/_data/universal-nav.yml
@@ -15,7 +15,7 @@ items:
         url: https://www.op-tee.org
       - title: DeviceTree.org
         url: https://www.devicetree.org
-      - title: OpenDataPlane.org
-        url: https://www.opendataplane.org
       - title: TrustedFirmware.org
         url: https://www.trustedfirmware.org
+      - title: OpenAMP
+        url: https://www.openampproject.org

--- a/_data/universal-nav.yml
+++ b/_data/universal-nav.yml
@@ -1,20 +1,21 @@
-- title: Linaro
-  url: https://www.linaro.org/
-- title: Connect
-  url: https://connect.linaro.org
-- title: 96Boards
-  url: https://www.96boards.org
-- title: Developer Cloud
-  url: https://linaro.cloud
-- title: Projects
-  options:
-    - title: 96Boards.ai
-      url: https://www.96boards.ai
-    - title: OP-TEE
-      url: https://www.op-tee.org
-    - title: DeviceTree.org
-      url: https://www.devicetree.org
-    - title: OpenDataPlane.org
-      url: https://www.opendataplane.org
-    - title: TrustedFirmware.org
-      url: https://www.trustedfirmware.org
+items:
+  - title: Linaro
+    url: https://www.linaro.org/
+  - title: Connect
+    url: https://connect.linaro.org
+  - title: 96Boards
+    url: https://www.96boards.org
+  - title: Developer Cloud
+    url: https://linaro.cloud
+  - title: Projects
+    options:
+      - title: 96Boards.ai
+        url: https://www.96boards.ai
+      - title: OP-TEE
+        url: https://www.op-tee.org
+      - title: DeviceTree.org
+        url: https://www.devicetree.org
+      - title: OpenDataPlane.org
+        url: https://www.opendataplane.org
+      - title: TrustedFirmware.org
+        url: https://www.trustedfirmware.org

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -6,6 +6,7 @@ description: >-
 permalink: /about/
 jumbotron:
     title: About
+    darken: true
     description: ""
     triangle-divider: true
     background-image: /assets/images/content/ml-banner.jpg

--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -6,6 +6,7 @@ description: >-
 permalink: /contact/
 jumbotron:
     title: Contact Us
+    darken: true
     description: ""
     background-image: /assets/images/content/ml-banner.jpg
 ---

--- a/_pages/contributing.md
+++ b/_pages/contributing.md
@@ -7,6 +7,7 @@ permalink: /contributing/
 jumbotron:
     title: Contributing
     description: ""
+    darken: true
     triangle-divider: true
     background-image: /assets/images/content/ml-banner.jpg
 ---

--- a/_pages/guides.md
+++ b/_pages/guides.md
@@ -6,6 +6,7 @@ description: >-
 permalink: /guides/
 jumbotron:
     title: Guides
+    darken: true
     description: ""
     triangle-divider: true
     background-image: /assets/images/content/ml-banner.jpg

--- a/_pages/mailing_lists_and_irc.md
+++ b/_pages/mailing_lists_and_irc.md
@@ -6,6 +6,7 @@ description: >-
 permalink: /mailing-lists-and-irc/
 jumbotron:
     title: Mailing Lists & IRC
+    darken: true
     description: ""
     triangle-divider: true
     background-image: /assets/images/content/ml-banner.jpg

--- a/_pages/releases.md
+++ b/_pages/releases.md
@@ -8,6 +8,7 @@ jumbotron:
     title: Releases
     description: The machine learning platform project releases are available on official GitHub repositories
     triangle-divider: true
+    darken: true
     background-image: /assets/images/content/ml-banner.jpg
 ---
 <div class="col-xs-12 col-sm-8 col-sm-offset-2">

--- a/_pages/resources.md
+++ b/_pages/resources.md
@@ -9,6 +9,7 @@ description: >
 jumbotron:
     title: Developer Resources
     description: ""
+    darken: true
     background-image: /assets/images/content/ml-banner.jpg
 flow:
     - row: custom_include_row


### PR DESCRIPTION
In an effort to get all of the Linaro Static sites using the same version of the jumbo-jekyll-theme, this PR updates the version to 5.6.5.