### PR TITLE
Update TOSA 1.0.2 release tag link

### DIFF
--- a/_pages/tosa_spec.md
+++ b/_pages/tosa_spec.md
@@ -22,7 +22,7 @@ flow:
             ## v1.0.2
             * [HTML](tosa_spec_1_0_2.html)
             * [PDF](/assets/pdf/tosa_spec_1_0_2.pdf) - <small><code>sha256: 23e3a52359e315742c25403251dcbb35e2518e834e28881ab5dca81d66b66455</code></small>
-            * [Git - <small><code>tag: v1.0.2-rc0</code></small>](https://github.com/arm/tosa-specification/tree/v1.0.2-rc0)
+            * [Git - <small><code>tag: v1.0.2</code></small>](https://github.com/arm/tosa-specification/tree/v1.0.2)
 
             ## v1.0.1
             * [HTML](tosa_spec_1_0_1.html)


### PR DESCRIPTION
Replace the v1.0.2-rc0 GitHub reference in the TOSA specification index with the final v1.0.2 release tag.